### PR TITLE
feat: roster templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "grooster-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@gewis/grooster-backend-ts": "^1.2.0",
+        "@gewis/grooster-backend-ts": "^1.3.0",
         "@primeuix/themes": "^1.1.1",
         "@primevue/forms": "^4.3.7",
         "@tailwindcss/vite": "^4.1.6",
@@ -1206,9 +1206,9 @@
       }
     },
     "node_modules/@gewis/grooster-backend-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@gewis/grooster-backend-ts/-/grooster-backend-ts-1.2.0.tgz",
-      "integrity": "sha512-6jBFkJs+DGwhLWTNLGDHbtX3HTNmhpX7E9Z4O3bZ3GXmGHO3gavKmSbQ9h4MMpAacsKUzSrriM7EeEBjPkiwQA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@gewis/grooster-backend-ts/-/grooster-backend-ts-1.3.0.tgz",
+      "integrity": "sha512-iNTqLh6zWQ+A9Ft+AXLQSbi3t/Ne/mJ9JmujSTNXoQN6m3ScT6xB2SUXufo5q5Z/giiUh+KchHJRI0t90TfcHw==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@gewis/eslint-config-typescript": "^2.4.0",
@@ -3184,9 +3184,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -7467,9 +7467,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@gewis/grooster-backend-ts": "^1.2.0",
+    "@gewis/grooster-backend-ts": "^1.3.0",
     "@primeuix/themes": "^1.1.1",
     "@primevue/forms": "^4.3.7",
     "@tailwindcss/vite": "^4.1.6",

--- a/src/components/templates/RosterTemplate.vue
+++ b/src/components/templates/RosterTemplate.vue
@@ -47,7 +47,7 @@ const showDetail = ref<boolean>(false);
     </div>
 
     <RosterTemplateDelete :open="openDeleteDialog" :template-id="props.template.id" @close="openDeleteDialog=false"/>
-    <RosterTemplateUseDialog :open="openRosterDialog" :name="'test'" :shifts="[]" @close="openRosterDialog=false"/>
+    <RosterTemplateUseDialog :open="openRosterDialog" :name="props.template.name" :shifts="props.template.shifts" @close="openRosterDialog=false"/>
 <!--    <RosterTemplateEdit :open="openEditDialog" :template="props.template" @close="openEditDialog=false"/>-->
 </template>
 

--- a/src/components/templates/dialogs/RosterTemplateAdd.vue
+++ b/src/components/templates/dialogs/RosterTemplateAdd.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import {computed, nextTick, reactive, ref} from "vue";
-import ApiService from "@/services/ApiService";
 import {RosterTemplateCreateRequest} from "@gewis/grooster-backend-ts";
 import {useRoute} from "vue-router";
 import {useTemplateStore} from "@/stores/template.store";

--- a/src/components/templates/dialogs/RosterTemplateUseDialog.vue
+++ b/src/components/templates/dialogs/RosterTemplateUseDialog.vue
@@ -28,11 +28,11 @@ const visible = computed({
 const date = ref(new Date());
 
 const addRoster = async () => {
-
     const createParams: RosterCreateRequest = {
         name: props.name,
         date: date.value.toISOString(),
-        organId: parseInt(route.params.id as string)
+        organId: parseInt(route.params.id as string),
+        shifts: props.shifts,
     }
 
     await ApiService.roster.createRoster(createParams);


### PR DESCRIPTION
Adds roster templates to the frontend. you can now make a template with a name and a n amount of shifts. Next to that you can delete them, the actual making of rosters with the template is not possible yet due to this not being implemented in the backend.