### PR TITLE
fix: roster templates for new client

### DIFF
--- a/src/components/templates/RosterTemplate.vue
+++ b/src/components/templates/RosterTemplate.vue
@@ -34,8 +34,8 @@ const showDetail = ref<boolean>(false);
         <!-- Detail section of card -->
         <div v-if="showDetail">
           <ul>
-            <li v-for="shift in props.template.shifts" :key="shift" class="flex justify-between items-center">
-              <span>{{ shift }}</span>
+            <li v-for="shift in props.template.shifts" :key="shift.id" class="flex justify-between items-center">
+              <span>{{ shift.shiftName }}</span>
             </li>
           </ul>
         </div>
@@ -47,7 +47,7 @@ const showDetail = ref<boolean>(false);
   <RosterTemplateUseDialog
     :name="props.template.name"
     :open="openRosterDialog"
-    :shifts="props.template.shifts"
+    :shifts="props.template.shifts.map((s) => s.shiftName)"
     @close="openRosterDialog = false"
   />
   <!--    <RosterTemplateEdit :open="openEditDialog" :template="props.template" @close="openEditDialog=false"/>-->

--- a/src/stores/template.store.ts
+++ b/src/stores/template.store.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { RosterTemplate } from '@gewis/grooster-backend-ts';
+import { RosterTemplate, RosterTemplateCreateRequest } from '@gewis/grooster-backend-ts';
 import ApiService from '@/services/ApiService';
 
 export const useTemplateStore = defineStore('rosterTemplate', {
@@ -29,7 +29,7 @@ export const useTemplateStore = defineStore('rosterTemplate', {
         console.error('Failed to fetch templates', error);
       }
     },
-    async createTemplate(params: RosterTemplate) {
+    async createTemplate(params: RosterTemplateCreateRequest) {
       try {
         const response = await ApiService.roster.createRosterTemplate(params);
         const template = response.data as RosterTemplate;


### PR DESCRIPTION
The client was updated that a template shift also had it's own model in de DB for later uses in preferences. This was not changed in the frontend yet thus were templates broken.

<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_