### PR TITLE
fix: assignment ordering same as shifts

### DIFF
--- a/src/components/roster/RosterAssignment.vue
+++ b/src/components/roster/RosterAssignment.vue
@@ -10,7 +10,19 @@ const props = defineProps<{
 const rosterStore = useRosterStore();
 const savedRoster = computed(() => {
   const data = rosterStore.getSavedRoster(props.id);
-  return Array.isArray(data) ? data : (data?.savedShifts ?? []);
+
+  if (!data) return [];
+
+  const shifts = data.savedShifts;
+
+  return [
+    ...shifts.sort((a, b) => {
+      const orderA = a.rosterShift.order ?? 0;
+      const orderB = b.rosterShift.order ?? 0;
+
+      return orderA - orderB;
+    }),
+  ];
 });
 
 const savedRosterOrdering = computed(() => {


### PR DESCRIPTION
Before the assignment would come in order of ID and not the same as the shifts on the top with their own order. This was changed by returning the savedRosters ordered by the ordering of their linked shift.

<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_