### PR TITLE
feat: select first upcoming roster

### DIFF
--- a/src/views/RosterView.vue
+++ b/src/views/RosterView.vue
@@ -36,7 +36,10 @@ onMounted(async () => {
   await fetchRosters();
 
   if (!rosterStore.selectedRosterId && rosters.value.length > 0) {
-    selectedRoster.value = rosters.value[0];
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const futureRosters = rosters.value.filter((roster) => new Date(roster.date) >= today);
+    selectedRoster.value = futureRosters.length > 0 ? futureRosters[0] : rosters.value[0];
   }
 });
 


### PR DESCRIPTION
As we had that old rosters stay shown for a week it would select that roster while it was not upcoming anymore. It is now changed such that it check everything that is today or later than today and get that roster.

close: #108 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_