### PR TITLE
feat: roster user comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "grooster-frontend",
             "version": "0.0.0",
             "dependencies": {
-                "@gewis/grooster-backend-ts": "^1.17.0",
+                "@gewis/grooster-backend-ts": "^1.19.0",
                 "@primeuix/themes": "^1.1.1",
                 "@primevue/forms": "^4.3.7",
                 "@tailwindcss/vite": "^4.1.6",
@@ -1156,7 +1156,9 @@
             }
         },
         "node_modules/@gewis/grooster-backend-ts": {
-            "version": "1.17.0",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/@gewis/grooster-backend-ts/-/grooster-backend-ts-1.19.0.tgz",
+            "integrity": "sha512-o/qB1/0G0RcG9BJbQTriPUKNKs/mG7MqAfgNc5O0rvJnUT0B9pFnIzWARZWXz7vDVve3sKYu3QzvtQcHbhed5A==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@gewis/eslint-config-typescript": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "format-fix": "prettier --ignore-path .gitignore --write ."
     },
     "dependencies": {
-        "@gewis/grooster-backend-ts": "^1.17.0",
+        "@gewis/grooster-backend-ts": "^1.19.0",
         "@primeuix/themes": "^1.1.1",
         "@primevue/forms": "^4.3.7",
         "@tailwindcss/vite": "^4.1.6",

--- a/src/components/roster/RosterTable.vue
+++ b/src/components/roster/RosterTable.vue
@@ -53,13 +53,45 @@ const loadUsers = async () => {
     });
 };
 
-onMounted(loadUsers);
+onMounted(() => {
+    void loadUsers();
+    void rosterStore.fetchComments(props.id);
+});
 
 const rosterValues = computed(() => Object.values(roster.value.values || {}));
 
 const shiftAnswers = reactive({});
 const visible = ref(false);
 const shiftName = ref('');
+
+const commentPopover = ref();
+const activeCommentUser = ref<UserWithNickname | null>(null);
+const commentDraft = ref('');
+
+const getUserComment = (userId: number) =>
+    rosterStore.getComments(props.id).find((comment) => comment.userId === userId)?.comment ?? '';
+
+function openCommentPopover(event: Event, user: UserWithNickname) {
+    activeCommentUser.value = user;
+    commentDraft.value = getUserComment(user.id);
+    commentPopover.value?.toggle(event);
+}
+
+async function saveComment() {
+    if (!activeCommentUser.value) return;
+
+    try {
+        await rosterStore.updateComment({
+            rosterId: props.id,
+            userId: activeCommentUser.value.id,
+            comment: commentDraft.value,
+        });
+
+        commentPopover.value?.hide();
+    } catch (error) {
+        console.error('Failed to save comment:', error);
+    }
+}
 
 watch(
     [() => roster.value, () => users.value],
@@ -287,6 +319,14 @@ const getStatusColorClass = (value: string) => {
                                 "
                             >
                                 {{ user.displayName || user.name }}
+                                <Button
+                                    class="p-0! w-6! h-6!"
+                                    icon="pi pi-comment"
+                                    rounded
+                                    size="small"
+                                    text
+                                    @click="openCommentPopover($event, user)"
+                                />
                             </div>
                         </td>
 
@@ -374,6 +414,34 @@ const getStatusColorClass = (value: string) => {
                 </div>
             </template>
         </Dialog>
+
+        <Popover ref="commentPopover" class="w-72">
+            <div v-if="activeCommentUser" class="flex flex-col gap-2">
+                <span class="text-sm font-medium text-gray-700">
+                    {{ activeCommentUser.displayName || activeCommentUser.name }}
+                </span>
+
+                <template v-if="activeCommentUser.gewis_id === getGEWISId()">
+                    <Textarea
+                        v-model="commentDraft"
+                        auto-resize
+                        class="w-full"
+                        maxlength="250"
+                        placeholder="Add a comment..."
+                        rows="3"
+                    />
+                    <span v-if="commentDraft.length >= 250" class="text-xs text-rose-600">
+                        Maximum length of 250 characters reached.
+                    </span>
+                    <Button label="Save" size="small" @click="saveComment" />
+                </template>
+                <template v-else>
+                    <p class="text-sm text-gray-600 whitespace-pre-wrap">
+                        {{ getUserComment(activeCommentUser.id) || 'No comment yet.' }}
+                    </p>
+                </template>
+            </div>
+        </Popover>
     </div>
 </template>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,8 @@ import DatePicker from 'primevue/datepicker';
 import { Form } from '@primevue/forms';
 import Chip from 'primevue/chip';
 import { Divider } from 'primevue';
+import Popover from 'primevue/popover';
+import Textarea from 'primevue/textarea';
 import App from './App.vue';
 import router from '@/router/router';
 
@@ -50,6 +52,8 @@ app.component('DatePicker', DatePicker);
 app.component('Form', Form);
 app.component('Chip', Chip);
 app.component('Divider', Divider);
+app.component('Popover', Popover);
+app.component('Textarea', Textarea);
 
 app.use(pinia);
 app.use(router);

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -9,11 +9,14 @@ import {
     ExportApi,
     OrganApi,
     ShiftGroupApi,
+    RosterCommentApi,
 } from '@gewis/grooster-backend-ts';
 import { getTokenFromStorage } from '@/helpers/TokenHelper';
 
 class ApiService {
     private readonly _rosterApi: RosterApi;
+
+    private readonly _rosterCommentApi: RosterCommentApi;
 
     private readonly _rosterAnswerApi: RosterAnswerApi;
 
@@ -41,6 +44,7 @@ class ApiService {
         });
 
         this._rosterApi = new RosterApi(config);
+        this._rosterCommentApi = new RosterCommentApi(config);
         this._rosterAnswerApi = new RosterAnswerApi(config);
         this._rosterShiftApi = new RosterShiftApi(config);
         this._savedShiftApi = new SavedShiftApi(config);
@@ -53,6 +57,10 @@ class ApiService {
 
     get roster(): RosterApi {
         return this._rosterApi;
+    }
+
+    get rosterComment(): RosterCommentApi {
+        return this._rosterCommentApi;
     }
 
     get rosterAnswer(): RosterAnswerApi {

--- a/src/stores/roster.store.ts
+++ b/src/stores/roster.store.ts
@@ -2,7 +2,9 @@ import { defineStore } from 'pinia';
 import type {
     AnswerCreateRequest,
     AnswerUpdateRequest,
+    CommentCreateRequest,
     Roster,
+    RosterComment,
     RosterCreateRequest,
     RosterUpdateRequest,
     SavedShiftResponse,
@@ -16,6 +18,7 @@ export const useRosterStore = defineStore('roster', {
     state: () => ({
         rosters: {} as Record<number, Roster>,
         savedRoster: {} as Record<number, SavedShiftResponse>,
+        comments: {} as Record<number, RosterComment[]>,
         selectedRosterId: null as number | null,
     }),
     persist: true,
@@ -28,6 +31,9 @@ export const useRosterStore = defineStore('roster', {
         },
         getSavedRoster: (state) => {
             return (rosterId: number) => state.savedRoster[rosterId];
+        },
+        getComments: (state) => {
+            return (rosterId: number) => state.comments[rosterId] ?? [];
         },
         selectedRoster: (state) => {
             return state.selectedRosterId ? state.rosters[state.selectedRosterId] : null;
@@ -139,6 +145,47 @@ export const useRosterStore = defineStore('roster', {
                 }
             } catch (error) {
                 console.error('Failed to update roster answer:', error);
+            }
+        },
+        async fetchComments(rosterId: number) {
+            try {
+                const response = await ApiService.rosterComment.getRosterComments(rosterId);
+
+                this.comments = {
+                    ...this.comments,
+                    [rosterId]: response.data,
+                };
+            } catch (error) {
+                console.error('Failed to fetch roster comments:', error);
+            }
+        },
+        async updateComment(params: CommentCreateRequest) {
+            try {
+                const response = await ApiService.rosterComment.createRosterComment(params);
+                const rosterId = response.data?.rosterId;
+
+                if (!rosterId) return response.data;
+
+                const existingComments = this.comments[rosterId] ?? [];
+                const commentIndex = existingComments.findIndex((comment) => comment.userId === params.userId);
+
+                const updatedComments =
+                    commentIndex !== -1
+                        ? [
+                              ...existingComments.slice(0, commentIndex),
+                              response.data,
+                              ...existingComments.slice(commentIndex + 1),
+                          ]
+                        : [...existingComments, response.data];
+
+                this.comments = {
+                    ...this.comments,
+                    [rosterId]: updatedComments,
+                };
+
+                return response.data;
+            } catch (error) {
+                console.error('Failed to save roster comment:', error);
             }
         },
         async createShift(params: ShiftCreateRequest) {


### PR DESCRIPTION
## Summary
- Add a per-user comment on each roster row, opened from a comment icon next to the user's name via a popover
- Comments are visible to everyone, but only editable by their own author
- Comments are capped at 250 characters, with an inline warning shown once the limit is reached

## Issues
close: #109 

## Test plan
- [x] Open a roster, click the comment icon on your own row, add/edit a comment, save, and confirm it persists after reload
- [x] Confirm another member's comment renders as read-only and cannot be edited
- [x] Type past 250 characters and confirm input is capped and the warning message appears